### PR TITLE
Update BaseDefinitionBuilder.cs

### DIFF
--- a/SolastaModApi/BuilderHelpers/BaseDefinitionBuilder.cs
+++ b/SolastaModApi/BuilderHelpers/BaseDefinitionBuilder.cs
@@ -159,6 +159,10 @@ namespace SolastaModApi
                 AddToDBIfMatch<FeatureDefinitionSavingThrowAffinity>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionTerrainTypeAffinity>(assertIfDuplicate);
             }
+            else if (Definition is SpellDefinition)
+            {
+                AddToDB<SpellDefinition>(Definition as SpellDefinition, assertIfDuplicate);
+            }
             else if (Definition is BaseBlueprint)
             {
                 AddToDBIfMatch<BaseBlueprint>(assertIfDuplicate);


### PR DESCRIPTION
- fixed BaseDefinitionBuilder AddToDB method to add SpellDefinition subclasses to SpellDefinition database (to allow subclassing SpellDefinition)