### PR TITLE
Update AddToDB method

### DIFF
--- a/Scripts/ParseAssets.linq
+++ b/Scripts/ParseAssets.linq
@@ -1,6 +1,6 @@
 <Query Kind="Program" />
 
-readonly string installDir = @"D:\Program Files (x86)\SteamLibrary\steamapps\common\Slasta_COTM_0_5_42";
+readonly string installDir = @"D:\Program Files (x86)\SteamLibrary\steamapps\common\Slasta_COTM";
 
 void Main()
 {
@@ -9,44 +9,50 @@ void Main()
 	// Read assets.txt and show assets that are stored in multiple databases
 	if (parseAssets)
 	{
-		File.ReadLines(@"C:\Users\passp\source\repos\SolastaModApi\Scripts\Assets.txt")
-			.Skip(1)
-			.Select(f => f.Split("\t"))
-			.Select(f => new { Name = f[0], Type = f[1], Database = f[2], Guid = f[3] })
-			.GroupBy(f => new { f.Name, f.Type })
-			.Select(g => new
-			{
-				g.Key.Type,
-				g.Key.Name,
-				DatabaseList = string.Join(", ", g.Select(x => x.Database).OrderBy(x => x))
-			})
-			.GroupBy(g => g.DatabaseList)
-			.Where(g => g.Any(x => x.Type != x.DatabaseList))
-			.Dump();
+		//File.ReadLines(@"C:\Users\passp\source\repos\SolastaModApi\Scripts\Assets.txt")
+		//	.Skip(1)
+		//	.Select(f => f.Split("\t"))
+		//	.Select(f => new { Name = f[0], Type = f[1], Database = f[2], Guid = f[3] })
+		//	.GroupBy(f => new { f.Name, f.Type })
+		//	.Select(g => new
+		//	{
+		//		g.Key.Type,
+		//		g.Key.Name,
+		//		DatabaseList = string.Join(", ", g.Select(x => x.Database).OrderBy(x => x))
+		//	})
+		//	.GroupBy(g => g.DatabaseList)
+		//	.Where(g => g.Any(x => x.Type != x.DatabaseList))
+		//	.Dump();
 	}
 
 	var assemblyDir = Path.Combine(installDir, @"Solasta_Data\Managed");
 	var assembly = Assembly.LoadFrom(Path.Combine(assemblyDir, @"Assembly-CSharp.dll"));
 
-// Types with these base classes are stored in multiple dbs:
+	// Types with these base classes are stored in multiple dbs:
 
-// FeatureDefinition
-// BasebluePrint
-// EditableGraphDefinition
-// RecordTableDefinition
+	// RecordTableDefinition
+	ShowTypes("RecordTableDefinition");
+	// FeatureDefinition
+	ShowTypes("FeatureDefinition");
+	// BasebluePrint
+	ShowTypes("BasebluePrint");
+	// EditableGraphDefinition
+	ShowTypes("EditableGraphDefinition");
+	// SpellDefinition?
+	ShowTypes("SpellDefinition");
 
-// quick and dirty code generation
+	// quick and dirty code generation
 
-	var types = GetDerivedTypes(assembly, "RecordTableDefinition");
-	//types.Dump();
-	
-	var sb = new StringBuilder();
-	foreach(var t in types.Select(t => t.type))
+	void ShowTypes(string baseType)
 	{
-		sb.Append($"if (Definition is {t.Name}) {{ AddToDB(Definition as {t.Name}, assertIfDuplicate); }}{Environment.NewLine}");	
+		$"--{baseType}-------".Dump();
+		var types = GetDerivedTypes(assembly, baseType);
+
+		foreach (var t in types.Select(t => t.type))
+		{
+			$"AddToDBIfMatch<{t.Name}>(assertIfDuplicate);".Dump();
+		}
 	}
-	
-	sb.ToString().Dump("");
 }
 
 

--- a/SolastaModApi/BuilderHelpers/BaseDefinitionBuilder.cs
+++ b/SolastaModApi/BuilderHelpers/BaseDefinitionBuilder.cs
@@ -100,13 +100,15 @@ namespace SolastaModApi
         {
             if (Definition is RecordTableDefinition)
             {
-                AddToDBIfMatch<RecordTableDefinition>(assertIfDuplicate);
                 AddToDBIfMatch<AdventureLogDefinition>(assertIfDuplicate);
                 AddToDBIfMatch<BestiaryStatsDefinition>(assertIfDuplicate);
                 AddToDBIfMatch<BestiaryTableDefinition>(assertIfDuplicate);
                 AddToDBIfMatch<ConsoleTableDefinition>(assertIfDuplicate);
+                AddToDBIfMatch<CreditsTableDefinition>(assertIfDuplicate);
                 AddToDBIfMatch<DailyLogDefinition>(assertIfDuplicate);
                 AddToDBIfMatch<DocumentTableDefinition>(assertIfDuplicate);
+                AddToDBIfMatch<RecordTableDefinition>(assertIfDuplicate);
+                AddToDBIfMatch<SubtitleTableDefinition>(assertIfDuplicate);
                 AddToDBIfMatch<TravelJournalDefinition>(assertIfDuplicate);
                 AddToDBIfMatch<TutorialTableDefinition>(assertIfDuplicate);
                 AddToDBIfMatch<TutorialTocDefinition>(assertIfDuplicate);
@@ -114,62 +116,63 @@ namespace SolastaModApi
             else if (Definition is FeatureDefinition)
             {
                 AddToDBIfMatch<FeatureDefinition>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionAbilityCheckAffinity>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionActionAffinity>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionAdditionalAction>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionAdditionalDamage>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionAffinity>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionAncestry>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionAttackModifier>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionAttributeModifier>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionAutoPreparedSpells>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionBonusCantrips>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionCampAffinity>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionCastSpell>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionCharacterPresentation>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionCriticalCharacter>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionFactionAffinity>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionFactionChange>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionFeatureSet>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionFightingStyleChoice>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionLightSource>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionLoreExpertise>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionMovementAffinity>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionMoveMode>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionPointPool>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionPower>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionProficiency>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionSchoolSavant>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionSense>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionSocialAffinity>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionSubclassChoice>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionAbilityCheckAffinity>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionAttackModifier>(assertIfDuplicate);
-                AddToDBIfMatch<FeatureDefinitionCampAffinity>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionCombatAffinity>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionConditionAffinity>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionCraftingAffinity>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionCriticalCharacter>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionDamageAffinity>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionDeathSavingThrowAffinity>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionDieRollModifier>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionEquipmentAffinity>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionFactionAffinity>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionFactionChange>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionFeatureSet>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionFightingStyleChoice>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionHealingModifier>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionLanguageAffinity>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionLightAffinity>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionLightSource>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionLoreExpertise>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionMagicAffinity>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionMovementAffinity>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionMoveMode>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionMoveThroughEnemyModifier>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionPerceptionAffinity>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionPointPool>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionPower>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionProficiency>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionRegeneration>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionSavingThrowAffinity>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionSchoolSavant>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionSense>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionSocialAffinity>(assertIfDuplicate);
+                AddToDBIfMatch<FeatureDefinitionSubclassChoice>(assertIfDuplicate);
                 AddToDBIfMatch<FeatureDefinitionTerrainTypeAffinity>(assertIfDuplicate);
             }
             else if (Definition is SpellDefinition)
             {
-                AddToDB<SpellDefinition>(Definition as SpellDefinition, assertIfDuplicate);
+                AddToDBIfMatch<SpellDefinition>(assertIfDuplicate);
             }
             else if (Definition is BaseBlueprint)
             {
                 AddToDBIfMatch<BaseBlueprint>(assertIfDuplicate);
                 AddToDBIfMatch<FurnitureBlueprint>(assertIfDuplicate);
-                AddToDBIfMatch<RoomBlueprint>(assertIfDuplicate);
                 AddToDBIfMatch<GadgetBlueprint>(assertIfDuplicate);
                 AddToDBIfMatch<PropBlueprint>(assertIfDuplicate);
+                AddToDBIfMatch<RoomBlueprint>(assertIfDuplicate);
             }
             else if (Definition is EditableGraphDefinition)
             {

--- a/SolastaModApi/BuilderHelpers/Repository.cs
+++ b/SolastaModApi/BuilderHelpers/Repository.cs
@@ -97,6 +97,10 @@ namespace SolastaModApi
             {
                 return Get<EditableGraphDefinition, TDefinition>(name, guid, throwIfNotFound);
             }
+            else if (t is SpellDefinition)
+            {
+                return Get<SpellDefinition, TDefinition>(name, guid, throwIfNotFound);
+            }
 
             return Get<TDefinition, TDefinition>(name, guid, throwIfNotFound);
         }


### PR DESCRIPTION
I've regenerated the list of AddToDBIfMatch.  There was one extra RecordTableDefinition.  Sorted the other lists.

Note that there are 94 types including SpellDefinition that could be special cased to allow for subclassing.  Is it worth adding all?
